### PR TITLE
working-with-nix-shells.md: Fix language of a code block

### DIFF
--- a/posts/working-with-nix-shells.md
+++ b/posts/working-with-nix-shells.md
@@ -66,7 +66,7 @@ pkgs.mkShell {
 
 And we can see this used like so:
 
-```nix
+```console
 $ nix-shell --run 'which hello; hello' # implicitly does `nix-shell shell.nix --run ...`
 /nix/store/some-hash-hello-2.10/bin/hello
 Hello, world!


### PR DESCRIPTION
This changes the language of a code block from `nix` to `console`.

I suggest changing all code blocks showing a bash session (those starting with `$`) from `bash` to `console` because they are not bash scripts.