### PR TITLE
Avoid perms error by using `cp` instead of `ln`

### DIFF
--- a/posts/your-first-derivation.md
+++ b/posts/your-first-derivation.md
@@ -37,8 +37,10 @@ pkgs.stdenv.mkDerivation {
   # $src is defined as the location of our `src` attribute above
   installPhase = ''
     # $out is an automatically generated filepath by nix,
-    # but it's up to you to make it what you need
-    ln -s $src $out
+    # but it's up to you to make it what you need. We'll create a directory at
+    # that filepath, then copy our sources into it.
+    mkdir $out
+    cp -rv $src/* $out
   '';
 }
 ```
@@ -89,9 +91,6 @@ $ nix-build
 ```bash
 $ readlink result
 /nix/store/kgjcq77210jkjppc8628vcl27i6f22k8-basic-derivation
-
-$ readlink -f result
-/nix/store/54992nknd3av7j4p7fmsh96ja5hp1vli-src
 
 $ ls result
 hi.txt


### PR DESCRIPTION
I confirmed #14 and came up with a fix: instead of using `ln` in the "your first derivation" short, we can use `mkdir` with `cp` to avoid the permissions error.

I am not sure why the fixup phase causes a permissions error when using `ln`, but I assume it has to do with the permissions for the source directory in the store not being mutable or something like that.

attn @humancalico

Closes #14 